### PR TITLE
Fix model syncing in widget editor

### DIFF
--- a/core/base_widgets/widget_editor.coffee
+++ b/core/base_widgets/widget_editor.coffee
@@ -91,7 +91,7 @@ define [], () ->
                     @widget.initializeWithForm(@form)
 
         getValue: () ->
-            return @widget?.getValue() or @default_value
+            return if @widget? then @widget.getValue() else @default_value
 
         setValue: (value) ->
             @value = value


### PR DESCRIPTION
- [x] null and undefined should be considered the same and shouldn't be synced (setting undefined in a model or editor might go through some castings and end up as null when asked for again, thus cause infinite loops when syncing the model with the form)
- [x] `getValue` should resort to `@default_value` when the widget is missing (not yet picked up by the widget starter) and not when it returns a _false_ value (see line 94)
