### PR TITLE
reference count is logged in as undefined, and the channel cannot be GC'ed though

### DIFF
--- a/core/datasource/datasource.coffee
+++ b/core/datasource/datasource.coffee
@@ -134,7 +134,6 @@ define [
                         # In theory, this won't longer be needed after we fix
                         # issue https://github.com/uberVU/mozaic/issues/54
                         @reference_data[channel_guid] = {
-                            'reference_count': 0
                             # Initial timestamp for channel, to know when to
                             # garbage collect it.
                             'time_of_reference_expiry': (new Date).getTime()


### PR DESCRIPTION
Some context:
- channel is created, but no widget uses it, so ref count is `undefined`, how is initialized in `newDataChannels`.
- `time_of_reference_expiry` is null when the channel is first created
- in `gc.coffee:channelCanBeGarbageCollected`, this piece of code will activate, because the `time_of_reference_expiry` is null

``` coffeescript
# If this channel still has references attached, so skip it.
unless reference['time_of_reference_expiry']?
    logger.info("Channel #{channel} cannot be garbage " +
                    "collected because it still has widgets " +
                    "referencing it. (reference count: #{reference.reference_count})")
    return false
```

so the channel will never have `time_of_reference_expiry` thus will not advance to return true to GC the channel.
