### PR TITLE
Keep track of all widgets subscribed to a channel

### DIFF
--- a/core/datasource/datasource.coffee
+++ b/core/datasource/datasource.coffee
@@ -138,7 +138,7 @@ define [
                             # empty object for referencing all widgets that
                             # will be subscribed to that channel at any
                             # specific point in time
-                            widgets: {}
+                            widgets: []
 
                         resource_type = @config.channel_types[channel_type].type
                         if resource_type == 'relational'

--- a/core/datasource/gc.coffee
+++ b/core/datasource/gc.coffee
@@ -125,7 +125,7 @@ define ['cs!channels_utils'], (channels_utils) ->
                 @reference_data[key]['reference_count'] += 1
                 # Store a direct reference to the widget as well, it helps
                 # debugging and providing more transparency to the datasource
-                @reference_data[key].widgets[widget.params.widget_id] = widget
+                @reference_data[key].widgets.push(widget.params.widget_id)
                 # This timestamp allows us to see for how long the channel
                 # has been inactive
                 @reference_data[key]['time_of_reference_expiry'] = null
@@ -146,7 +146,9 @@ define ['cs!channels_utils'], (channels_utils) ->
                 @reference_data[channel]['reference_count'] -= 1
                 # Remove this widget's reference from the channel reference
                 # data because they will no longer be tied together
-                delete @reference_data[channel].widgets[widget.params.widget_id]
+                @reference_data[channel].widgets =
+                    _.without(@reference_data[channel].widgets,
+                              widget.params.widget_id)
                 if @reference_data[channel]['reference_count'] == 0
                     @reference_data[channel]['time_of_reference_expiry'] = (new Date).getTime()
 


### PR DESCRIPTION
## Story

``` gherkin
As a Mozaic developer
I want to be able to track all widget subscribed to a channel at any given time
So that debug easier the connection between widgets and channels
    And how they are GCed
```

This gets us one tiny step closer to the Chrome dev extension @topliceanu was envisioning
