### PR TITLE
Fix condition in todo rendering, so it only updates for change events

### DIFF
--- a/modules/todo/widget/todo.coffee
+++ b/modules/todo/widget/todo.coffee
@@ -18,7 +18,7 @@ define ['cs!widget'], (Widget) ->
                 Whenever any field of a TODO item changes, re-render it completely.
             ###
             # TODO, remove itself when undefined
-            if not params or not params.type == 'change'
+            if not params or params.type isnt 'change'
                 return
 
             # Fetch model


### PR DESCRIPTION
The widget was supposed to re-render only when `change` events occurred. But in coffee the old condition (`if not params or not params.type == 'change'`) was translated to
```js
if (!params || !params.type === 'change')
```
Which resulted in re-rendering the widget for any type of event (i.e. `change_attribute`).

The new code transpiles to 
```js
if (!params || params.type !== 'change')
```